### PR TITLE
:bug: Use lib function to make ko in crash-altsysrq-c

### DIFF
--- a/crash-altsysrq-c/runtest.sh
+++ b/crash-altsysrq-c/runtest.sh
@@ -24,25 +24,13 @@
 
 C_REBOOT="./C_REBOOT"
 
-load_altsysrq_driver()
-{
-    mkdir altsysrq
-    cd altsysrq
-    cp ../altsysrq.c .
-    cp ../Makefile.altsysrq Makefile
-    unset ARCH
-    ( make && insmod ./altsysrq.ko )|| log_error "- make/insmod altsysrq module fail"
-    export ARCH
-    ARCH=$(uname -i)
-    cd ..
-}
-
 crash_altsysrq_c()
 {
     if [ ! -f ${C_REBOOT} ]; then
         kdump_prepare
         kdump_restart
-        load_altsysrq_driver
+        make_module "altsysrq"
+        insmod ./altsysrq/altsysrq.ko || log_error "- Fail to insmod altsysrq"
         touch "${C_REBOOT}"
         log_info "- boot to 2nd kernel"
         echo 1 > /proc/sys/kernel/sysrq


### PR DESCRIPTION
Fixes #28
Replace load_altsysrq_driver() in crash-altsysrq-c with library method
kdump.make_module() in crash-altsysrq-c

Signed-off-by: Zamir SUN <sztsian@gmail.com>